### PR TITLE
Cap the return value of StatHorse.randomizer

### DIFF
--- a/src/main/java/com/github/boltydawg/horseoverhaul/StatHorse.java
+++ b/src/main/java/com/github/boltydawg/horseoverhaul/StatHorse.java
@@ -114,7 +114,7 @@ public class StatHorse{
 		else
 			max = max * (Math.random() * 0.25 + 0.9);
 		
-		return Math.random() * (max-min) + min;
+		return Math.min(1.0, Math.random() * (max-min) + min);
 	}
 	
 	/**


### PR DESCRIPTION
It's possible for the randomizer to return values greater than 1 if the max and min are very similar values above 0.8. 
This change wraps the return value in `Math.min(1, X)` to prevent this occurring.